### PR TITLE
Use session state defaults for load inputs

### DIFF
--- a/streamlit_app/components/load_builder.py
+++ b/streamlit_app/components/load_builder.py
@@ -42,8 +42,18 @@ def show():
 
     st.markdown("---")
     st.write("Or create a synthetic profile:")
-    base_load = st.number_input("Base Load (kW)", min_value=0.0, value=100.0, key="base_load_kw")
-    peak_load = st.number_input("Peak Load (kW)", min_value=0.0, value=300.0, key="peak_load_kw")
+    base_load = st.number_input(
+        "Base Load (kW)",
+        min_value=0.0,
+        value=st.session_state.get("base_load_kw", 100.0),
+        key="base_load_kw",
+    )
+    peak_load = st.number_input(
+        "Peak Load (kW)",
+        min_value=0.0,
+        value=st.session_state.get("peak_load_kw", 300.0),
+        key="peak_load_kw",
+    )
 
     # Respect Settings.time_steps_per_hour if the UI has it
     tph = 1


### PR DESCRIPTION
## Summary
- pull base and peak load defaults from Streamlit session state

## Testing
- `pytest` *(fails: HTTPConnectionPool(host='127.0.0.1', port=8000): Max retries exceeded with url)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b65389f8832197ba67d883d8e241