### PR TITLE
Use session state defaults for resilience inputs

### DIFF
--- a/streamlit_app/components/resilience.py
+++ b/streamlit_app/components/resilience.py
@@ -5,9 +5,20 @@ def show():
 
     st.checkbox("Resilience Mode (Backup Power)", key="resilience_mode")
     if st.session_state.get("resilience_mode"):
-        st.number_input("Critical Load Fraction (0-1)", min_value=0.0, max_value=1.0, value=0.5, key="critical_load_fraction")
+        st.number_input(
+            "Critical Load Fraction (0-1)",
+            min_value=0.0,
+            max_value=1.0,
+            value=st.session_state.get("critical_load_fraction", 0.5),
+            key="critical_load_fraction",
+        )
         # keep both outage duration (hours) and editable start/end time steps
-        hours = st.number_input("Outage Duration (hours)", min_value=0, value=24, key="outage_hours")
+        hours = st.number_input(
+            "Outage Duration (hours)",
+            min_value=0,
+            value=st.session_state.get("outage_hours", 24),
+            key="outage_hours",
+        )
         # Convert outage hours into end time step relative to start=0 for simple UX
         try:
             tph = int(st.session_state.get("time_steps_per_hour", 1) or 1)


### PR DESCRIPTION
## Summary
- pull critical load fraction and outage duration defaults from session state

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a0b6557d1c8321a504f0d31d0fb21b