### PR TITLE
Avoid overwriting session values when zero

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -88,10 +88,9 @@ def _sync_scenario_to_session():
     def _set_if_empty(key, value):
         if value is None:
             return
-        existing = st.session_state.get(key, None)
-        if existing not in (None, "", 0):  # Avoid overwriting non-empty values
-            return
-        st.session_state[key] = value
+        existing = st.session_state.get(key)
+        if existing is None or existing == "":  # Only overwrite when no existing value
+            st.session_state[key] = value
 
     if "name" in site:
         _set_if_empty("site_name", site.get("name"))


### PR DESCRIPTION
## Summary
- Only overwrite session state entries when their current value is `None` or an empty string

## Testing
- `python -m py_compile streamlit_app/app.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a0b65863f88321a21d0c4f4aacbadc