### PR TITLE
Ensure Streamlit widgets persist state via session_state defaults

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,7 +21,8 @@ makedocs(
             "developer/organization.md",
             "developer/inputs.md",
             "developer/adding_tech.md",
-            "developer/documentation.md"
+            "developer/documentation.md",
+            "developer/streamlit.md"
         ]
     ],
     workdir = joinpath(@__DIR__, "..")

--- a/docs/src/developer/streamlit.md
+++ b/docs/src/developer/streamlit.md
@@ -1,0 +1,20 @@
+# Streamlit Component Guidelines
+
+When creating or modifying Streamlit components, ensure user input values
+persist across reruns by sourcing default values from
+`st.session_state`.
+
+```python
+st.number_input(
+    "Discount Rate (%)",
+    min_value=0.0,
+    value=st.session_state.get("discount_rate_pct", 6.0),
+    key="discount_rate_pct",
+)
+```
+
+Always reference `st.session_state.get()` for a widget's `value` (or
+`index` for widgets such as `st.radio`) and pass the same key so that the
+selection is stored and restored on rerun. This consistent pattern helps
+prevent regressions in state handling across the application.
+

--- a/streamlit_app/components/grid_tariff.py
+++ b/streamlit_app/components/grid_tariff.py
@@ -3,7 +3,15 @@ import streamlit as st
 def show():
     st.header("⚡ Grid & Tariff")
 
-    st.radio("Connection Type", ["Grid-Connected", "Off-Grid"], key="grid_connection")
+    connection_options = ["Grid-Connected", "Off-Grid"]
+    st.radio(
+        "Connection Type",
+        connection_options,
+        index=connection_options.index(
+            st.session_state.get("grid_connection", "Grid-Connected")
+        ),
+        key="grid_connection",
+    )
 
     if st.session_state.get("grid_connection") == "Grid-Connected":
         st.text_input("Utility", key="utility_name", value=st.session_state.get("utility_name", ""))

--- a/streamlit_app/components/load_builder.py
+++ b/streamlit_app/components/load_builder.py
@@ -42,8 +42,18 @@ def show():
 
     st.markdown("---")
     st.write("Or create a synthetic profile:")
-    base_load = st.number_input("Base Load (kW)", min_value=0.0, value=100.0, key="base_load_kw")
-    peak_load = st.number_input("Peak Load (kW)", min_value=0.0, value=300.0, key="peak_load_kw")
+    base_load = st.number_input(
+        "Base Load (kW)",
+        min_value=0.0,
+        value=st.session_state.get("base_load_kw", 100.0),
+        key="base_load_kw",
+    )
+    peak_load = st.number_input(
+        "Peak Load (kW)",
+        min_value=0.0,
+        value=st.session_state.get("peak_load_kw", 300.0),
+        key="peak_load_kw",
+    )
 
     # Respect Settings.time_steps_per_hour if the UI has it
     tph = 1

--- a/streamlit_app/components/resilience.py
+++ b/streamlit_app/components/resilience.py
@@ -3,11 +3,26 @@ import streamlit as st
 def show():
     st.header("🛡️ Resilience Settings")
 
-    st.checkbox("Resilience Mode (Backup Power)", key="resilience_mode")
+    st.checkbox(
+        "Resilience Mode (Backup Power)",
+        key="resilience_mode",
+        value=st.session_state.get("resilience_mode", False),
+    )
     if st.session_state.get("resilience_mode"):
-        st.number_input("Critical Load Fraction (0-1)", min_value=0.0, max_value=1.0, value=0.5, key="critical_load_fraction")
+        st.number_input(
+            "Critical Load Fraction (0-1)",
+            min_value=0.0,
+            max_value=1.0,
+            value=st.session_state.get("critical_load_fraction", 0.5),
+            key="critical_load_fraction",
+        )
         # keep both outage duration (hours) and editable start/end time steps
-        hours = st.number_input("Outage Duration (hours)", min_value=0, value=24, key="outage_hours")
+        hours = st.number_input(
+            "Outage Duration (hours)",
+            min_value=0,
+            value=st.session_state.get("outage_hours", 24),
+            key="outage_hours",
+        )
         # Convert outage hours into end time step relative to start=0 for simple UX
         try:
             tph = int(st.session_state.get("time_steps_per_hour", 1) or 1)

--- a/streamlit_app/components/results_daily_ops.py
+++ b/streamlit_app/components/results_daily_ops.py
@@ -15,7 +15,13 @@ def show():
     total_hours = len(results.get("ElectricLoad", {}).get("load_series_kw", [])) or (8760 * tph)
     max_day = max(0, total_hours // (24 * tph) - 1)
 
-    day = st.slider("Day of year", min_value=0, max_value=max_day, value=0)
+    day = st.slider(
+        "Day of year",
+        min_value=0,
+        max_value=max_day,
+        value=st.session_state.get("daily_ops_day", 0),
+        key="daily_ops_day",
+    )
     df = to_daily_series(results, day_index=day, tph=tph)
 
     st.altair_chart(daily_ops_chart(df), use_container_width=True)


### PR DESCRIPTION
## Summary
- Load Streamlit widgets with defaults from `st.session_state` so user selections persist across reruns
- Add developer guidelines and build config entry documenting session state usage in Streamlit components

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68a0b659699883218e4bfd48070d5952