### PR TITLE
Sync grid connection with scenario flag

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -83,8 +83,7 @@ def _sync_scenario_to_session():
     if st.session_state.get("_synced_from_scenario", False):
         return
     sc = st.session_state.get("scenario", {}) or {}
-    # Site
-    site = sc.get("Site", {}) or {}
+
     def _set_if_empty(key, value):
         if value is None:
             return
@@ -93,6 +92,16 @@ def _sync_scenario_to_session():
             return
         st.session_state[key] = value
 
+    # Settings
+    settings = sc.get("Settings", {}) or {}
+    if "off_grid_flag" in settings:
+        _set_if_empty(
+            "grid_connection",
+            "Off-Grid" if settings.get("off_grid_flag") else "Grid-Connected",
+        )
+
+    # Site
+    site = sc.get("Site", {}) or {}
     if "name" in site:
         _set_if_empty("site_name", site.get("name"))
     if "site_location" in site:

--- a/streamlit_app/tests/test_sync_scenario_to_session.py
+++ b/streamlit_app/tests/test_sync_scenario_to_session.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import streamlit as st
+
+# Ensure repo root and streamlit_app are on sys.path
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+if str(ROOT / "streamlit_app") not in sys.path:
+    sys.path.append(str(ROOT / "streamlit_app"))
+
+from streamlit_app.app import _sync_scenario_to_session
+
+
+def test_off_grid_flag_sets_selection():
+    st.session_state.clear()
+    st.session_state["scenario"] = {"Settings": {"off_grid_flag": True}}
+    _sync_scenario_to_session()
+    assert st.session_state["grid_connection"] == "Off-Grid"


### PR DESCRIPTION
## Summary
- populate `grid_connection` from `Settings.off_grid_flag` when session state is empty
- test off-grid scenarios load "Off-Grid" selection

## Testing
- `pytest streamlit_app/tests/test_sync_scenario_to_session.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0b69b13088321ad7a428053c2550c