### PR TITLE
Preserve grid connection selection

### DIFF
--- a/streamlit_app/components/grid_tariff.py
+++ b/streamlit_app/components/grid_tariff.py
@@ -3,7 +3,14 @@ import streamlit as st
 def show():
     st.header("⚡ Grid & Tariff")
 
-    st.radio("Connection Type", ["Grid-Connected", "Off-Grid"], key="grid_connection")
+    options = ["Grid-Connected", "Off-Grid"]
+    default_connection = st.session_state.get("grid_connection", "Grid-Connected")
+    st.radio(
+        "Connection Type",
+        options,
+        key="grid_connection",
+        index=options.index(default_connection)
+    )
 
     if st.session_state.get("grid_connection") == "Grid-Connected":
         st.text_input("Utility", key="utility_name", value=st.session_state.get("utility_name", ""))


### PR DESCRIPTION
## Summary
- retain chosen grid connection radio option when navigating pages or loading saved scenarios

## Testing
- `pytest` *(fails: No module named 'backend'; HTTPConnectionPool host 127.0.0.1 port 8000 connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b6aed94c8321b1e9ebf4f980fcc7