### PR TITLE
Add xlsxwriter dependency

### DIFF
--- a/streamlit_app/requirements.txt
+++ b/streamlit_app/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.31
 pandas>=2.2
 numpy>=1.26
 altair>=5.3
+xlsxwriter>=3.0


### PR DESCRIPTION
## Summary
- add xlsxwriter>=3.0 to Streamlit requirements

## Testing
- `pip install -r streamlit_app/requirements.txt`
- `pytest streamlit_app/tests/test_sync_scenario_to_session.py`


------
https://chatgpt.com/codex/tasks/task_e_68a33bd55acc8321b967efb09f2639d4