### PR TITLE
Add centrifuge load model component and utilities

### DIFF
--- a/streamlit_app/components/centrifuge_load_model.py
+++ b/streamlit_app/components/centrifuge_load_model.py
@@ -1,0 +1,178 @@
+"""Streamlit UI for the centrifuge load model.
+
+This component exposes a simple interface for configuring a
+``CentrifugeParams`` object, running the load model, and downloading the
+results.  Parameters and results are persisted in ``st.session_state`` to
+allow seamless interaction across reruns.
+"""
+
+from __future__ import annotations
+
+import json
+import io
+from dataclasses import asdict
+
+import streamlit as st
+
+from streamlit_app.utils.centrifuge_load_model import (
+    CentrifugeParams,
+    build_centrifuge_load_curve,
+)
+
+
+_PARAMS_KEY = "centrifuge_params"
+_RESULTS_KEY = "centrifuge_results"
+
+
+def _get_params() -> CentrifugeParams:
+    if _PARAMS_KEY not in st.session_state:
+        st.session_state[_PARAMS_KEY] = CentrifugeParams()
+    return st.session_state[_PARAMS_KEY]
+
+
+def _get_results():
+    return st.session_state.get(_RESULTS_KEY)
+
+
+def show() -> None:
+    """Render the centrifuge load model UI."""
+
+    st.subheader("🌀 Centrifuge Load Model")
+    params = _get_params()
+
+    # --- JSON import/export controls ---
+    c1, c2 = st.columns(2)
+    with c1:
+        uploaded = st.file_uploader("Import Params JSON", type="json", key="centrifuge_params_upload")
+        if uploaded is not None:
+            try:
+                raw = json.load(uploaded)
+                st.session_state[_PARAMS_KEY] = CentrifugeParams(**{**asdict(CentrifugeParams()), **raw})
+                params = _get_params()
+                st.success("Parameters loaded.")
+            except Exception as exc:  # pragma: no cover - defensive
+                st.error(f"Failed to parse JSON: {exc}")
+    with c2:
+        st.download_button(
+            "Export Params JSON",
+            data=json.dumps(asdict(params), indent=2),
+            file_name="centrifuge_params.json",
+            mime="application/json",
+        )
+
+    # --- Parameter tabs ---
+    tab_pp, tab_elec, tab_ops, tab_run = st.tabs(
+        ["Plant & Process", "Electrical & HVAC", "Spin-up & Ops", "Run & Results"]
+    )
+
+    with tab_pp:
+        params.plant_swu_per_year = st.number_input(
+            "Plant SWU/year", value=float(params.plant_swu_per_year), min_value=0.0
+        )
+        params.kwh_per_swu = st.number_input(
+            "kWh per SWU", value=float(params.kwh_per_swu), min_value=0.0
+        )
+        params.interpret_kwh_per_swu_as_total_plant = st.checkbox(
+            "Interpret kWh/SWU as total plant",
+            value=params.interpret_kwh_per_swu_as_total_plant,
+        )
+        params.machine_swu_per_year = st.number_input(
+            "SWU per machine per year",
+            value=float(params.machine_swu_per_year),
+            min_value=0.0,
+        )
+        params.availability = st.number_input(
+            "Availability (0-1)", value=float(params.availability), min_value=0.0, max_value=1.0, step=0.01
+        )
+        params.num_cascades = st.number_input(
+            "Number of cascades", value=int(params.num_cascades), min_value=1, step=1
+        )
+        params.year = st.number_input("Year", value=int(params.year), step=1)
+
+    with tab_elec:
+        params.hvac_fraction_of_running = st.number_input(
+            "HVAC fraction of running load",
+            value=float(params.hvac_fraction_of_running),
+            min_value=0.0,
+            step=0.01,
+        )
+        params.hvac_seasonal_amplitude = st.number_input(
+            "HVAC seasonal amplitude",
+            value=float(params.hvac_seasonal_amplitude),
+            min_value=0.0,
+            step=0.01,
+        )
+        params.season_peak_month = st.number_input(
+            "Season peak month", value=int(params.season_peak_month), min_value=1, max_value=12, step=1
+        )
+        params.aux_kw_constant = st.number_input(
+            "Auxiliary constant kW", value=float(params.aux_kw_constant), min_value=0.0
+        )
+        params.ride_through_seconds = st.number_input(
+            "Ride-through seconds", value=float(params.ride_through_seconds), min_value=0.0
+        )
+        params.critical_fraction = st.number_input(
+            "Critical load fraction",
+            value=float(params.critical_fraction),
+            min_value=0.0,
+            max_value=1.0,
+            step=0.01,
+        )
+
+    with tab_ops:
+        params.daily_restart_fraction = st.number_input(
+            "Daily restart fraction",
+            value=float(params.daily_restart_fraction),
+            min_value=0.0,
+            max_value=1.0,
+            step=0.001,
+            format="%.3f",
+        )
+        params.spinup_minutes = st.number_input(
+            "Spin-up minutes", value=float(params.spinup_minutes), min_value=0.0
+        )
+        params.spinup_power_factor = st.number_input(
+            "Spin-up power factor", value=float(params.spinup_power_factor), min_value=0.0
+        )
+        start, end = params.spinup_window_hours
+        start_end = st.slider(
+            "Spin-up window hours",
+            min_value=0,
+            max_value=24,
+            value=(int(start), int(end)),
+        )
+        params.spinup_window_hours = (start_end[0], start_end[1])
+        params.random_seed = st.number_input("Random seed", value=int(params.random_seed), step=1)
+
+    with tab_run:
+        if st.button("Run model", key="centrifuge_run"):
+            with st.spinner("Building load curve..."):
+                df, summary = build_centrifuge_load_curve(params)
+                st.session_state[_RESULTS_KEY] = {"df": df, "summary": summary}
+        res = _get_results()
+        if res:
+            df = res["df"]
+            summary = res["summary"]
+            st.success("Model run complete.")
+            st.line_chart(df["total_kw"], height=200)
+            st.json(summary)
+
+            csv_buf = io.StringIO()
+            df.to_csv(csv_buf)
+            st.download_button(
+                "Download CSV", data=csv_buf.getvalue(), file_name="centrifuge_load_curve.csv", mime="text/csv"
+            )
+            reopt_payload = {
+                "ElectricLoad": {
+                    "loads_kw": [float(x) for x in df["total_kw"].round(3)],
+                    "year": int(params.year),
+                }
+            }
+            st.download_button(
+                "Download REopt JSON",
+                data=json.dumps(reopt_payload, indent=2),
+                file_name="centrifuge_reopt_payload.json",
+                mime="application/json",
+            )
+
+    st.session_state[_PARAMS_KEY] = params

--- a/streamlit_app/utils/centrifuge_load_model.py
+++ b/streamlit_app/utils/centrifuge_load_model.py
@@ -1,0 +1,192 @@
+"""Centrifuge load model utilities.
+
+This module exposes a dataclass describing key parameters for a gas-
+centrifuge enrichment plant and a helper to generate an 8760-hour load
+curve.  The implementation is adapted from the research prototype in
+``data/load_profiles/GeM/GeM_Load_Generation.py`` but trimmed down for
+use within the Streamlit application.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Tuple
+import math
+import warnings
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class CentrifugeParams:
+    """Input parameters for the centrifuge load model."""
+
+    # Plant-scale production
+    plant_swu_per_year: float = 1_000_000.0
+    kwh_per_swu: float = 55.0
+    interpret_kwh_per_swu_as_total_plant: bool = False
+
+    # Centrifuge fleet assumptions
+    machine_swu_per_year: float = 300.0
+    availability: float = 0.96
+    num_cascades: int = 20
+
+    # Spin-up / restart dynamics
+    daily_restart_fraction: float = 0.005
+    spinup_minutes: float = 20.0
+    spinup_power_factor: float = 3.5
+    spinup_window_hours: Tuple[int, int] = (6, 22)
+
+    # HVAC & Aux loads
+    hvac_fraction_of_running: float = 0.30
+    aux_kw_constant: float = 1500.0
+
+    # Seasonal HVAC modulation
+    hvac_seasonal_amplitude: float = 0.20
+    season_peak_month: int = 7
+
+    # Ride-through study
+    ride_through_seconds: float = 20.0
+    critical_fraction: float = 0.80
+
+    # Timeframe
+    year: int = 2025
+
+    # Randomness
+    random_seed: int = 42
+
+
+def _seasonal_multiplier(index: pd.DatetimeIndex, peak_month: int, amplitude: float) -> np.ndarray:
+    months = index.month.values
+    angles = (months - peak_month) * (2.0 * np.pi / 12.0)
+    return 1.0 + amplitude * np.cos(angles)
+
+
+def build_centrifuge_load_curve(params: CentrifugeParams) -> Tuple[pd.DataFrame, Dict[str, float]]:
+    """Build an 8760-hour load curve for the centrifuge plant.
+
+    Parameters
+    ----------
+    params : CentrifugeParams
+        Model inputs.
+
+    Returns
+    -------
+    df : pandas.DataFrame
+        Indexed by timestamp with columns ``centrifuge_kw``, ``hvac_kw``,
+        ``aux_kw``, ``spinup_kw``, ``spinup_count`` and ``total_kw``.
+    summary : dict
+        Key performance metrics and UPS ride-through sizing.
+    """
+
+    np.random.seed(params.random_seed)
+
+    hours_in_year = 8760
+    start = datetime(params.year, 1, 1)
+    index = pd.date_range(start, periods=hours_in_year, freq="H")
+
+    annual_kwh_target = params.plant_swu_per_year * params.kwh_per_swu
+
+    running_mask = np.ones(hours_in_year, dtype=bool)
+    num_running_hours = int(round(hours_in_year * params.availability))
+    downtime_count = hours_in_year - num_running_hours
+    if downtime_count > 0:
+        downtime_idx = np.linspace(0, hours_in_year - 1, downtime_count, dtype=int)
+        running_mask[downtime_idx] = False
+
+    hvac_seasonal = _seasonal_multiplier(index, params.season_peak_month, params.hvac_seasonal_amplitude)
+
+    if not params.interpret_kwh_per_swu_as_total_plant:
+        avg_centrifuge_kw_all_hours = annual_kwh_target / hours_in_year
+        centrifuge_running_kw_total = avg_centrifuge_kw_all_hours / max(params.availability, 1e-6)
+    else:
+        avg_centrifuge_kw_all_hours = annual_kwh_target / hours_in_year
+        centrifuge_running_kw_total = avg_centrifuge_kw_all_hours / max(params.availability, 1e-6)
+
+    num_centrifuges = int(math.ceil(params.plant_swu_per_year / max(params.machine_swu_per_year, 1e-9)))
+    per_machine_kw = centrifuge_running_kw_total / max(num_centrifuges, 1)
+
+    centrifuge_kw = np.where(running_mask, centrifuge_running_kw_total, 0.0)
+    hvac_kw = params.hvac_fraction_of_running * centrifuge_kw * hvac_seasonal
+    aux_kw = np.full(hours_in_year, params.aux_kw_constant, dtype=float)
+
+    spinup_kw = np.zeros(hours_in_year, dtype=float)
+    spinup_count = np.zeros(hours_in_year, dtype=int)
+
+    machines_per_day_restart = int(round(params.daily_restart_fraction * num_centrifuges))
+    window_start, window_end = params.spinup_window_hours
+    window_start = max(0, min(23, int(window_start)))
+    window_end = max(1, min(24, int(window_end)))
+    if window_end <= window_start:
+        window_end = min(window_start + 1, 24)
+    spinup_hours = list(range(window_start, window_end))
+
+    minutes_frac = params.spinup_minutes / 60.0
+    extra_kw_per_machine = (params.spinup_power_factor - 1.0) * per_machine_kw
+
+    for day in range(365):
+        if machines_per_day_restart <= 0 or not spinup_hours:
+            continue
+        chosen_hours = np.random.choice(spinup_hours, size=machines_per_day_restart, replace=True)
+        counts: Dict[int, int] = {}
+        for h in chosen_hours:
+            counts[h] = counts.get(h, 0) + 1
+        for h, count in counts.items():
+            hour_idx = day * 24 + h
+            if 0 <= hour_idx < hours_in_year and running_mask[hour_idx]:
+                spinup_kw[hour_idx] += count * extra_kw_per_machine * minutes_frac
+                spinup_count[hour_idx] += count
+
+    total_kw = centrifuge_kw + hvac_kw + aux_kw + spinup_kw
+
+    if params.interpret_kwh_per_swu_as_total_plant:
+        target_annual_kwh = annual_kwh_target
+        current_annual_kwh = float(total_kw.sum())
+        if current_annual_kwh > 0:
+            scale = target_annual_kwh / current_annual_kwh
+            centrifuge_kw *= scale
+            hvac_kw *= scale
+            aux_kw *= scale
+            spinup_kw *= scale
+            total_kw *= scale
+            centrifuge_running_kw_total *= scale
+            per_machine_kw *= scale
+        else:
+            warnings.warn("Total kWh computed as zero; scaling skipped.")
+
+    p90 = float(np.percentile(total_kw, 90))
+    critical_kw = params.critical_fraction * p90
+    ups_kwh_required = critical_kw * (params.ride_through_seconds / 3600.0)
+
+    df = pd.DataFrame(
+        {
+            "running_mask": running_mask.astype(int),
+            "centrifuge_kw": centrifuge_kw,
+            "hvac_kw": hvac_kw,
+            "aux_kw": aux_kw,
+            "spinup_kw": spinup_kw,
+            "spinup_count": spinup_count,
+            "total_kw": total_kw,
+        },
+        index=index,
+    )
+
+    summary = {
+        "plant_swu_per_year": params.plant_swu_per_year,
+        "kwh_per_swu": params.kwh_per_swu,
+        "interpret_kwh_per_swu_as_total_plant": params.interpret_kwh_per_swu_as_total_plant,
+        "machine_swu_per_year": params.machine_swu_per_year,
+        "num_centrifuges": num_centrifuges,
+        "availability": params.availability,
+        "avg_kw_over_year": float(np.mean(total_kw)),
+        "peak_kw": float(np.max(total_kw)),
+        "p95_kw": float(np.percentile(total_kw, 95)),
+        "p50_kw": float(np.percentile(total_kw, 50)),
+        "annual_mwh": float(np.sum(total_kw) / 1000.0),
+        "estimated_ups_kwh_required_for_ridethrough": float(ups_kwh_required),
+        "ups_ridethrough_seconds": params.ride_through_seconds,
+        "critical_fraction": params.critical_fraction,
+    }
+    return df, summary


### PR DESCRIPTION
## Summary
- add centrifuge load model utilities with configurable parameters and 8760h curve generator
- create Streamlit component with tabs, session-state persistence, JSON import/export, and CSV/REopt downloads

## Testing
- `pytest -q` *(fails: httpx missing and backend not running)*
- `pytest streamlit_app/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a33bc187a083218a2efdbe355b834d