### PR TITLE
Fix off-grid flag handling and stream backend logs

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# Make backend a package for test imports

--- a/streamlit_app/utils/validators.py
+++ b/streamlit_app/utils/validators.py
@@ -60,7 +60,11 @@ def build_reopt_scenario(state: dict) -> tuple[dict, list]:
     settings = scn["Settings"]
     site = scn["Site"]
     settings["time_steps_per_hour"] = sget("time_steps_per_hour", 1)
-    settings["off_grid_flag"] = (sget("grid_connection") == "Off-Grid") or bool(sget("off_grid_flag", False))
+    settings["off_grid_flag"] = (
+        (sget("grid_connection") == "Off-Grid")
+        or bool(sget("off_grid_flag", False))
+        or bool(card("Settings").get("off_grid_flag"))
+    )
     # Allow the user to enter a 'site_location' free-text field containing either 'lat, lon' or a 5-digit ZIP
     site_loc = sget("site_location") or card("Site").get("site_location")
     lat = sget("latitude") or card("Site").get("latitude")


### PR DESCRIPTION
## Summary
- ensure off-grid checkbox propagates into built scenario JSON
- stream Julia stdout/stderr to backend terminal and log submit scenarios
- add backend package `__init__` for test imports

## Testing
- `pytest -q`
- `pytest backend -q` *(fails: KeyboardInterrupt after ~4min waiting for run completion)*

------
https://chatgpt.com/codex/tasks/task_e_68a34d8db9d08321a019a1b348e24006