### PR TITLE
Ensure GeoInterfaceRecipes installed for run_reopt

### DIFF
--- a/scripts/run_reopt.jl
+++ b/scripts/run_reopt.jl
@@ -6,6 +6,7 @@ import Pkg
 # disable automatic package precompilation to avoid GeoInterfaceRecipes method overwrite errors
 ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0"
 Pkg.activate(joinpath(@__DIR__, ".."))
+Pkg.add("GeoInterfaceRecipes")
 
 using REopt, JuMP
 import HiGHS


### PR DESCRIPTION
## Summary
- ensure `GeoInterfaceRecipes` is available by adding it before `run_reopt` loads REopt

## Testing
- `julia -e 'using Pkg; println("Pkg loaded")'` *(fails: Package `Pkg` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a36997840083219bb88ba576e2ec03