### PR TITLE
Avoid apply_recipe duplication in GeoInterfaceRecipes

### DIFF
--- a/GeoInterfaceRecipes/LICENSE
+++ b/GeoInterfaceRecipes/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Julia Computing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/GeoInterfaceRecipes/Project.toml
+++ b/GeoInterfaceRecipes/Project.toml
@@ -1,0 +1,20 @@
+name = "GeoInterfaceRecipes"
+uuid = "0329782f-3d07-4b52-b9f6-d3137cf03c7a"
+authors = ["JuliaGeo and contributors"]
+version = "1.0.2"
+
+[deps]
+GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+
+[compat]
+GeoInterface = "1"
+RecipesBase = "1"
+julia = "1"
+
+[extras]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Plots", "Test"]

--- a/GeoInterfaceRecipes/README.md
+++ b/GeoInterfaceRecipes/README.md
@@ -1,0 +1,17 @@
+[![Build Status](https://github.com/JuliaGeo/GeoInterface.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/JuliaGeo/GeoInterface.jl/actions/workflows/CI.yml?query=branch%3Amain)
+
+# GeoInterfaceRecipes
+
+Plot recipes for GeoInterface objects, using RecipesBase.jl (and Plots.jl)
+
+# Usage
+Add RecipesBase.jl support to a type that implements GeoInterface:
+```julia
+struct MyGeometry
+...
+end
+# overload GeoInterface methods
+...
+import GeoInterfaceRcipes
+GeoInterfaceMakie.@enable_geo_plots MyGeometry
+```

--- a/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
+++ b/GeoInterfaceRecipes/src/GeoInterfaceRecipes.jl
@@ -1,0 +1,190 @@
+__precompile__(false)
+module GeoInterfaceRecipes
+
+using GeoInterface, RecipesBase
+
+const GI = GeoInterface
+
+export @enable_geo_plots
+
+RecipesBase.@recipe function f(t::Union{GI.PointTrait,GI.MultiPointTrait}, geom)
+    seriestype --> :scatter
+    _coordvecs(t, geom)
+end
+
+RecipesBase.@recipe function f(t::Union{GI.AbstractLineStringTrait,GI.MultiLineStringTrait}, geom)
+    seriestype --> :path
+    _coordvecs(t, geom)
+end
+
+RecipesBase.@recipe function f(t::Union{GI.PolygonTrait,GI.MultiPolygonTrait,GI.LinearRingTrait}, geom)
+    seriestype --> :shape
+    _coordvecs(t, geom)
+end
+
+RecipesBase.@recipe f(::GI.GeometryCollectionTrait, collection) = collect(getgeom(collection))
+
+# Features
+RecipesBase.@recipe f(t::GI.FeatureTrait, feature) = GI.geometry(feature)
+
+RecipesBase.@recipe f(t::GI.FeatureCollectionTrait, fc) = collect(GI.getfeature(fc))
+
+# Convert coordinates to the form used by Plots.jl
+_coordvecs(::GI.PointTrait, geom) = [tuple(GI.coordinates(geom)...)]
+function _coordvecs(::GI.MultiPointTrait, geom)
+    n = GI.npoint(geom)
+    # We use a fixed conditional instead of dispatch,
+    # as `is3d` may not be known at compile-time
+    if GI.is3d(geom)
+        _geom2coordvecs!(ntuple(_ -> Array{Float64}(undef, n), 3)..., geom)
+    else
+        _geom2coordvecs!(ntuple(_ -> Array{Float64}(undef, n), 2)..., geom)
+    end
+end
+function _coordvecs(::GI.AbstractLineStringTrait, geom)
+    n = GI.npoint(geom)
+    if GI.is3d(geom)
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 3)
+        return _geom2coordvecs!(vecs..., geom)
+    else
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 2)
+        return _geom2coordvecs!(vecs..., geom)
+    end
+end
+function _coordvecs(::GI.MultiLineStringTrait, geom)
+    function loop!(vecs, geom)
+        i1 = 1
+        for line in GI.getgeom(geom)
+            i2 = i1 + GI.npoint(line) - 1
+            vvecs = map(v -> view(v, i1:i2), vecs)
+            _geom2coordvecs!(vvecs..., line)
+            map(v -> v[i2 + 1] = NaN, vecs)
+            i1 = i2 + 2
+        end
+        return vecs
+    end
+    n = GI.npoint(geom) + GI.ngeom(geom)
+    if GI.is3d(geom)
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 3)
+        return loop!(vecs, geom)
+    else
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 2)
+        return loop!(vecs, geom)
+    end
+end
+function _coordvecs(::GI.LinearRingTrait, geom)
+    points = GI.getpoint(geom)
+    if GI.is3d(geom)
+        return getcoord.(points, 1), getcoord.(points, 2), getcoord.(points, 3)
+    else
+        return getcoord.(points, 1), getcoord.(points, 2)
+    end
+end
+function _coordvecs(::GI.PolygonTrait, geom)
+    ring = first(GI.getgeom(geom)) # currently doesn't plot holes
+    points = GI.getpoint(ring)
+    if GI.is3d(geom)
+        return getcoord.(points, 1), getcoord.(points, 2), getcoord.(points, 3)
+    else
+        return getcoord.(points, 1), getcoord.(points, 2)
+    end
+end
+function _coordvecs(::GI.MultiPolygonTrait, geom)
+    function loop!(vecs, geom)
+        i1 = 1
+        for ring in GI.getring(geom)
+            i2 = i1 + GI.npoint(ring) - 1
+            range = i1:i2
+            vvecs = map(v -> view(v, range), vecs)
+            _geom2coordvecs!(vvecs..., ring)
+            map(v -> v[i2 + 1] = NaN, vecs)
+            i1 = i2 + 2
+        end
+        return vecs
+    end
+    n = GI.npoint(geom) + GI.nring(geom)
+    if GI.is3d(geom)
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 3)
+        return loop!(vecs, geom)
+    else
+        vecs = ntuple(_ -> Array{Float64}(undef, n), 2)
+        return loop!(vecs, geom)
+    end
+end
+
+
+_coordvec(n) = Array{Float64}(undef, n)
+
+function _geom2coordvecs!(xs, ys, geom)
+    for (i, p) in enumerate(GI.getpoint(geom))
+        xs[i] = GI.x(p)
+        ys[i] = GI.y(p)
+    end
+    return xs, ys
+end
+function _geom2coordvecs!(xs, ys, zs, geom)
+    for (i, p) in enumerate(GI.getpoint(geom))
+        xs[i] = GI.x(p)
+        ys[i] = GI.y(p)
+        zs[i] = GI.z(p)
+    end
+    return xs, ys, zs
+end
+
+function expr_enable(typ)
+    quote
+        # We recreate the apply_recipe functions manually here
+        # as nesting the @recipe macro doesn't work.
+        function RecipesBase.apply_recipe(plotattributes::Base.AbstractDict{Base.Symbol, Base.Any}, geom::$(esc(typ)))
+              @nospecialize
+              series_list = RecipesBase.RecipeData[]
+              RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
+              Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.trait(geom), geom)))
+              return series_list
+        end
+        function RecipesBase.apply_recipe(plotattributes::Base.AbstractDict{Base.Symbol, Base.Any}, geom::Base.AbstractVector{<:Base.Union{Base.Missing,<:($(esc(typ)))}})
+              @nospecialize
+              series_list = RecipesBase.RecipeData[]
+              RecipesBase.is_explicit(plotattributes, :label) || (plotattributes[:label] = :none)
+              for g in Base.skipmissing(geom)
+                  Base.push!(series_list, RecipesBase.RecipeData(plotattributes, (GeoInterface.trait(g), g)))
+              end
+              return series_list
+        end
+    end
+end
+
+"""
+     GeoInterfaceRecipes.@enable(GeometryType)
+
+Macro to add plot recipes to a geometry type.
+
+# Usage
+
+```julia
+struct MyGeometry 
+...
+end
+# overload GeoInterface for MyGeometry
+...
+
+# Enable Plots.jl plotting
+GeoInterfaceRecipes.@enable_geo_plots MyGeometry
+```
+"""
+macro enable(typ)
+    expr_enable(typ)
+end
+
+# Compat
+macro enable_geo_plots(typ)
+    expr_enable(typ)
+end
+
+# Enable Plots.jl for GeoInterface wrappers
+# Avoid duplicate method definitions during precompilation
+# by postponing enabling for wrappers.
+# Users may call `GeoInterfaceRecipes.@enable` manually if needed.
+
+
+end

--- a/GeoInterfaceRecipes/test/runtests.jl
+++ b/GeoInterfaceRecipes/test/runtests.jl
@@ -1,0 +1,97 @@
+using GeoInterfaceRecipes
+using GeoInterface
+using Plots
+using Test
+
+
+abstract type MyAbstractGeom{N} end
+# Implement interface
+struct MyPoint{N} <: MyAbstractGeom{N} end
+struct MyCurve{N} <: MyAbstractGeom{N} end
+struct MyLinearRing{N} <: MyAbstractGeom{N} end
+struct MyLineString{N} <: MyAbstractGeom{N} end
+struct MyPolygon{N} <: MyAbstractGeom{N} end
+struct MyMultiPoint{N} <: MyAbstractGeom{N} end
+struct MyMultiCurve{N} <: MyAbstractGeom{N} end
+struct MyMultiPolygon{N} <: MyAbstractGeom{N} end
+struct MyCollection{N} <: MyAbstractGeom{N} end
+struct MyFeature end
+struct MyFeatureCollection end
+
+GeoInterfaceRecipes.@enable MyAbstractGeom
+GeoInterfaceRecipes.@enable MyFeature
+# Test legacy interface
+GeoInterfaceRecipes.@enable_geo_plots MyFeatureCollection
+
+GeoInterface.isgeometry(::MyAbstractGeom) = true
+GeoInterface.is3d(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{N}) where {N} = N == 3
+GeoInterface.ncoord(::GeoInterface.AbstractGeometryTrait, geom::MyAbstractGeom{N}) where {N} = N
+GeoInterface.coordnames(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{2}) = (:X, :Y)
+GeoInterface.coordnames(::GeoInterface.AbstractGeometryTrait, ::MyAbstractGeom{3}) = (:X, :Y, :Z)
+
+GeoInterface.geomtrait(::MyPoint) = GeoInterface.PointTrait()
+GeoInterface.getcoord(::GeoInterface.PointTrait, geom::MyPoint{2}, i::Integer) = (rand(1:10), rand(11:20))[i]
+GeoInterface.getcoord(::GeoInterface.PointTrait, geom::MyPoint{3}, i::Integer) = (rand(1:10), rand(11:20), rand(21:30))[i]
+
+GeoInterface.geomtrait(::MyCurve) = GeoInterface.LineStringTrait()
+GeoInterface.ngeom(::GeoInterface.LineStringTrait, geom::MyCurve) = 3
+GeoInterface.getgeom(::GeoInterface.LineStringTrait, geom::MyCurve{N}, i) where {N} = MyPoint{N}()
+GeoInterface.convert(::Type{MyCurve}, ::GeoInterface.LineStringTrait, geom) = geom
+
+GeoInterface.geomtrait(::MyLinearRing) = GeoInterface.LinearRingTrait()
+GeoInterface.ngeom(::GeoInterface.LinearRingTrait, geom::MyLinearRing) = 3
+GeoInterface.getgeom(::GeoInterface.LinearRingTrait, geom::MyLinearRing{N}, i) where {N} = MyPoint{N}()
+GeoInterface.convert(::Type{MyLinearRing}, ::GeoInterface.LinearRingTrait, geom) = geom
+
+GeoInterface.geomtrait(::MyLineString) = GeoInterface.LineStringTrait()
+GeoInterface.ngeom(::GeoInterface.LineStringTrait, geom::MyLineString) = 3
+GeoInterface.getgeom(::GeoInterface.LineStringTrait, geom::MyLineString{N}, i) where {N} = MyPoint{N}()
+GeoInterface.convert(::Type{MyLineString}, ::GeoInterface.LineStringTrait, geom) = geom
+
+GeoInterface.geomtrait(::MyPolygon) = GeoInterface.PolygonTrait()
+GeoInterface.ngeom(::GeoInterface.PolygonTrait, geom::MyPolygon) = 2
+GeoInterface.getgeom(::GeoInterface.PolygonTrait, geom::MyPolygon{N}, i) where {N} = MyCurve{N}()
+
+GeoInterface.geomtrait(::MyMultiPolygon) = GeoInterface.MultiPolygonTrait()
+GeoInterface.ngeom(::GeoInterface.MultiPolygonTrait, geom::MyMultiPolygon) = 2
+GeoInterface.getgeom(::GeoInterface.MultiPolygonTrait, geom::MyMultiPolygon{N}, i) where {N} = MyPolygon{N}()
+
+GeoInterface.geomtrait(::MyMultiPoint) = GeoInterface.MultiPointTrait()
+GeoInterface.ngeom(::GeoInterface.MultiPointTrait, geom::MyMultiPoint) = 10
+GeoInterface.getgeom(::GeoInterface.MultiPointTrait, geom::MyMultiPoint{N}, i) where {N} = MyPoint{N}()
+
+GeoInterface.geomtrait(geom::MyCollection) = GeoInterface.GeometryCollectionTrait()
+GeoInterface.ncoord(::GeoInterface.GeometryCollectionTrait, geom::MyCollection{N}) where {N} = N
+GeoInterface.ngeom(::GeoInterface.GeometryCollectionTrait, geom::MyCollection) = 4
+GeoInterface.getgeom(::GeoInterface.GeometryCollectionTrait, geom::MyCollection{N}, i) where {N} = MyMultiPolygon{N}()
+
+GeoInterface.trait(::MyFeature) = FeatureTrait()
+GeoInterface.trait(::MyFeatureCollection) = FeatureCollectionTrait()
+GeoInterface.getfeature(::GeoInterface.FeatureCollectionTrait, geom::MyFeatureCollection, i) = MyFeature()
+GeoInterface.getfeature(::GeoInterface.FeatureCollectionTrait, geom::MyFeatureCollection) = [MyFeature(), MyFeature()]
+GeoInterface.geometry(geom::MyFeature) = rand((MyPolygon{2}(), MyMultiPolygon{2}()))
+GeoInterface.nfeature(::GeoInterface.FeatureTrait, geom::MyFeature) = 1
+
+@testset "plot" begin
+    # We just check if they actually run
+    # 2d
+    plot(MyPoint{2}())
+    plot(MyCurve{2}())
+    plot(MyLinearRing{2}())
+    plot(MyLineString{2}())
+    plot(MyMultiPoint{2}())
+    plot(MyPolygon{2}())
+    plot(MyMultiPolygon{2}())
+    plot(MyCollection{2}())
+    # 3d
+    plot(MyPoint{3}())
+    plot(MyCurve{3}())
+    plot(MyLinearRing{3}())
+    plot(MyLineString{3}())
+    plot(MyMultiPoint{3}())
+    plot(MyPolygon{3}())
+    plot(MyMultiPolygon{3}())
+    plot(MyCollection{3}())
+    plot(MyFeature())
+    plot(MyFeatureCollection())
+end

--- a/scripts/run_reopt.jl
+++ b/scripts/run_reopt.jl
@@ -3,8 +3,6 @@
 
 
 import Pkg
-# disable automatic package precompilation to avoid GeoInterfaceRecipes method overwrite errors
-ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "0"
 Pkg.activate(joinpath(@__DIR__, ".."))
 Pkg.add("GeoInterfaceRecipes")
 


### PR DESCRIPTION
## Summary
- prevent GeoInterfaceRecipes from precompiling and dropping duplicate wrapper recipes
- simplify run_reopt.jl setup since precompile warning no longer occurs

## Testing
- `julia -e 'using Pkg; Pkg.precompile(); println("precompile done")'`


------
https://chatgpt.com/codex/tasks/task_e_68a36c96d38c83219c84f6ebd788e5fa