### PR TITLE
Normalize financial inputs for REopt submission

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -153,6 +153,44 @@ def _normalize_scenario(scn: dict) -> dict:
     filtered_tx = {k: v for k, v in tx.items() if k in allowed_tx_keys}
     s["ElectricTariff"] = filtered_tx
 
+    # Financial normalization: strip unknown keys to avoid Julia MethodError
+    fin = s.get("Financial", {}) or {}
+    allowed_fin_keys = {
+        "analysis_years",
+        "offtaker_discount_rate_fraction",
+        "elec_cost_escalation_rate_fraction",
+        "om_cost_escalation_rate_fraction",
+        "offtaker_tax_rate_fraction",
+        "third_party_ownership",
+        "owner_tax_rate_fraction",
+        "owner_discount_rate_fraction",
+        "existing_boiler_fuel_cost_escalation_rate_fraction",
+        "boiler_fuel_cost_escalation_rate_fraction",
+        "chp_fuel_cost_escalation_rate_fraction",
+        "generator_fuel_cost_escalation_rate_fraction",
+        "value_of_lost_load_per_kwh",
+        "microgrid_upgrade_cost_fraction",
+        "macrs_five_year",
+        "macrs_seven_year",
+        "offgrid_other_capital_costs",
+        "offgrid_other_annual_costs",
+        "min_initial_capital_costs_before_incentives",
+        "max_initial_capital_costs_before_incentives",
+        "CO2_cost_per_tonne",
+        "CO2_cost_escalation_rate_fraction",
+        "NOx_grid_cost_per_tonne",
+        "SO2_grid_cost_per_tonne",
+        "PM25_grid_cost_per_tonne",
+        "NOx_onsite_fuelburn_cost_per_tonne",
+        "SO2_onsite_fuelburn_cost_per_tonne",
+        "PM25_onsite_fuelburn_cost_per_tonne",
+        "NOx_cost_escalation_rate_fraction",
+        "SO2_cost_escalation_rate_fraction",
+        "PM25_cost_escalation_rate_fraction",
+    }
+    filtered_fin = {k: v for k, v in fin.items() if k in allowed_fin_keys}
+    s["Financial"] = filtered_fin
+
     return s
 
 

--- a/backend/test_api.py
+++ b/backend/test_api.py
@@ -3,7 +3,7 @@ import os
 import json
 import pytest
 from fastapi.testclient import TestClient
-from backend.reopt_api_client import app
+from backend.api import app
 
 client = TestClient(app)
 
@@ -92,14 +92,13 @@ def test_run_reopt():
             "analysis_years": 25,
             "offtaker_discount_rate_fraction": 0.08,
             "elec_cost_escalation_rate_fraction": 0.025,
-            "itc": 0.3,
-            "macrs_option_years": 5,
-            "bonus_depreciation_fraction": 0.0,
-            "capital_incentive": 0.0,
+            "om_cost_escalation_rate_fraction": 0.025,
+            "offtaker_tax_rate_fraction": 0.26,
+            "third_party_ownership": False,
         },
     }
 
-    response = client.post("/reopt/run", json={"scenario": scenario})
+    response = client.post("/reopt/run", json=scenario)
     assert response.status_code == 200
     assert "run_id" in response.json()
 

--- a/streamlit_app/utils/validators.py
+++ b/streamlit_app/utils/validators.py
@@ -159,6 +159,17 @@ def build_reopt_scenario(state: dict) -> tuple[dict, list]:
     es.setdefault("installed_cost_per_kw", 150.0)
     es.setdefault("soc_min_fraction", 0.1)
 
+    # Apply simplified incentive inputs to PV and ElectricStorage
+    itc = sget("itc", 0.30)
+    macrs_years = sget("macrs_option_years", 5)
+    bonus = sget("bonus_depreciation_fraction", 0.0)
+    pv.setdefault("federal_itc_fraction", itc)
+    pv.setdefault("macrs_option_years", macrs_years)
+    pv.setdefault("macrs_bonus_fraction", bonus)
+    es.setdefault("itc_fraction", itc)
+    es.setdefault("macrs_option_years", macrs_years)
+    es.setdefault("macrs_bonus_fraction", bonus)
+
     # NG (CHP) and Diesel map straight through if user enabled them in your cards
     if card("CHP"):
         scn["CHP"] = card("CHP")
@@ -181,10 +192,9 @@ def build_reopt_scenario(state: dict) -> tuple[dict, list]:
     fin["analysis_years"] = sget("analysis_years", 25)
     fin["offtaker_discount_rate_fraction"] = sget("offtaker_discount_rate_fraction", 0.08)
     fin["elec_cost_escalation_rate_fraction"] = sget("elec_cost_escalation_rate_fraction", 0.025)
-    fin["itc"] = sget("itc", 0.30)
-    fin["macrs_option_years"] = sget("macrs_option_years", 5)
-    fin["bonus_depreciation_fraction"] = sget("bonus_depreciation_fraction", 0.0)
-    fin["capital_incentive"] = sget("capital_incentive", 0.0)
+    fin["om_cost_escalation_rate_fraction"] = sget("om_cost_escalation_rate_fraction", 0.025)
+    fin["offtaker_tax_rate_fraction"] = sget("offtaker_tax_rate_fraction", 0.26)
+    fin["third_party_ownership"] = sget("third_party_ownership", False)
 
     # validations
     err = _validate_load(scn)


### PR DESCRIPTION
## Summary
- strip unsupported fields from Financial block before invoking REopt
- map global incentive fields to PV and battery tech inputs and clean Financial
- align API tests with new payload structure

## Testing
- `pytest streamlit_app/tests/test_sync_scenario_to_session.py -q`
- `pytest streamlit_app/tests/test_centrifuge_load_model.py -q` *(fails: No module named 'data.load_profiles.GeM')*
- `pytest backend/test_api.py::test_run_reopt_invalid_scenario -q`

------
https://chatgpt.com/codex/tasks/task_e_68a39a7ff9448321a24e48eefc9c3b98