### PR TITLE
feat: add option to run REopt via NREL API

### DIFF
--- a/streamlit_app/utils/backend_client.py
+++ b/streamlit_app/utils/backend_client.py
@@ -3,6 +3,12 @@ import requests
 
 BACKEND_URL = os.getenv("VORTX_BACKEND_URL", "http://localhost:8000")
 
+# Configuration for calling the hosted NREL REopt API
+NREL_API_BASE = os.getenv(
+    "NREL_REOPT_API_BASE", "https://developer.nrel.gov/api/reopt/v3"
+)
+NREL_API_KEY = os.getenv("NREL_API_KEY") or os.getenv("NREL_DEVELOPER_API_KEY")
+
 def get_schema():
     r = requests.get(f"{BACKEND_URL}/schema", timeout=30)
     r.raise_for_status()
@@ -51,5 +57,39 @@ def get_result(run_uuid: str):
     caller.
     """
     r = requests.get(f"{BACKEND_URL}/reopt/result/{run_uuid}", timeout=60)
+    r.raise_for_status()
+    return r.json()
+
+
+# ---------------------------------------------------------------------------
+# NREL-hosted REopt API helpers
+# ---------------------------------------------------------------------------
+
+def _nrel_payload(payload: dict) -> dict:
+    """Wrap the scenario payload with API key for NREL-hosted runs."""
+    if not NREL_API_KEY:
+        raise RuntimeError("NREL_API_KEY environment variable not set")
+    return {"api_key": NREL_API_KEY, "scenario": payload}
+
+
+def submit_scenario_nrel(payload: dict):
+    data = _nrel_payload(payload)
+    r = requests.post(f"{NREL_API_BASE}/job", json=data, timeout=60)
+    r.raise_for_status()
+    return r.json()
+
+
+def get_status_nrel(run_uuid: str):
+    params = {"api_key": NREL_API_KEY}
+    # Many REopt API versions expose /job/<id>/status
+    r = requests.get(f"{NREL_API_BASE}/job/{run_uuid}/status", params=params, timeout=60)
+    r.raise_for_status()
+    return r.json()
+
+
+def get_result_nrel(run_uuid: str):
+    params = {"api_key": NREL_API_KEY}
+    # Final detailed results
+    r = requests.get(f"{NREL_API_BASE}/job/{run_uuid}/results", params=params, timeout=60)
     r.raise_for_status()
     return r.json()


### PR DESCRIPTION
## Summary
- allow selecting between local backend or NREL hosted API when running REopt
- add helper functions for submitting, polling, and retrieving results from NREL REopt API

## Testing
- `pytest streamlit_app/tests` *(fails: No module named 'data.load_profiles.GeM')*
- `pytest streamlit_app/tests/test_sync_scenario_to_session.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3a2e763f4832195cce7dbb0269602